### PR TITLE
return quantity struct from conversion

### DIFF
--- a/lib/ex_dimensions/conversions/conversions.ex
+++ b/lib/ex_dimensions/conversions/conversions.ex
@@ -7,9 +7,13 @@ defmodule ExDimensions.Conversions do
   require ExDimensions.Conversions.Graph
   @before_compile ExDimensions.Conversions.Graph
 
-  def %{value: v1, units: u, denom: []} ~> u2 when is_list(u2) do
-    {:ok, value} = convert(v1, u, u2)
-    %{value: value, units: u2, denom: []}
+  alias ExDimensions.Quantity
+
+  def %Quantity{value: v1, units: u, denom: []} ~> u2 when is_list(u2) do
+    case convert(v1, u, u2) do
+      {:ok, value} -> %Quantity{value: value, units: u2, denom: []}
+      err -> err
+    end
   end
 
   @doc """
@@ -26,9 +30,9 @@ defmodule ExDimensions.Conversions do
       "12 in"
   """
   @doc since: "0.1.0"
-  def %{value: v1, units: u, denom: []} ~> u2 do
+  def %Quantity{value: v1, units: u, denom: []} ~> u2 do
     case convert(v1, u, [u2]) do
-      {:ok, value} -> %{value: value, units: [u2], denom: []}
+      {:ok, value} -> %Quantity{value: value, units: [u2], denom: []}
       err -> err
     end
   end

--- a/test/conversion_test.exs
+++ b/test/conversion_test.exs
@@ -1,17 +1,40 @@
 defmodule ExDimension.ConversionTest do
-  use ExUnit.Case
-  import ExDimensions.Conversions
   use ExDimensions.Math
+  use ExUnit.Case
+
+  import ExDimensions.Conversions
+
+  alias ExDimensions.Quantity
 
   test "convert one simple unit to another" do
-    u = ExDimensions.Spatial.inches(4)
-    assert (u ~> ExDimensions.Spatial.Millimeters).value == 101.6
+    inches = ExDimensions.Spatial.inches(4)
+    mm = inches ~> ExDimensions.Spatial.Millimeters
+
+    assert %Quantity{
+             value: 101.6,
+             units: [ExDimensions.Spatial.Millimeters]
+           } = mm
   end
 
   test "convert complex units to another" do
-    u = ExDimensions.Area.square_inches(4)
-    assert (u ~> (ExDimensions.Spatial.Millimeters ^^^ 2)).value == 2580.64
-    u2 = ExDimensions.Volume.cubic_inches(4)
-    assert (u2 ~> (ExDimensions.Spatial.Millimeters ^^^ 3)).value == 65548.4
+    sq_in = ExDimensions.Area.square_inches(4)
+    mm_sq = sq_in ~> (ExDimensions.Spatial.Millimeters ^^^ 2)
+
+    assert %Quantity{
+             value: 2580.64,
+             units: [ExDimensions.Spatial.Millimeters, ExDimensions.Spatial.Millimeters]
+           } = mm_sq
+
+    cu_in = ExDimensions.Volume.cubic_inches(4)
+    mm_cu = cu_in ~> (ExDimensions.Spatial.Millimeters ^^^ 3)
+
+    assert %Quantity{
+             value: 65548.4,
+             units: [
+               ExDimensions.Spatial.Millimeters,
+               ExDimensions.Spatial.Millimeters,
+               ExDimensions.Spatial.Millimeters
+             ]
+           } = mm_cu
   end
 end


### PR DESCRIPTION
### What
Changed the convert sigil (`~>`) function signature to only operate on and return `%Quantity{}`

### Why
Converting a `Quantity` from one unit to another works as expected. However, attempting to update a model with the value returned from the conversion results in this error:

```
** (FunctionClauseError) no function clause matching in ExDimensions.Ecto.UnitField.cast/1

The following arguments were given to ExDimensions.Ecto.UnitField.cast/1:

  # 1
  %{denom: [], units: [ExDimensions.Spatial.Inches, ExDimensions.Spatial.Inches, ExDimensions.Spatial.Inches], value: 0.00976377760555559}

  Attempted function clauses (showing 2 out of 2):

    def cast(%ExDimensions.Quantity{} = quantity)
    def cast(%{"denom" => denom, "units" => units, "value" => value})
```

The reason is because the conversion is returning a map, rather than the `Quantity` struct.