### PR TITLE
fix: deserialization of micrometer units

### DIFF
--- a/lib/ex_dimensions/parser.ex
+++ b/lib/ex_dimensions/parser.ex
@@ -2,7 +2,7 @@ defmodule ExDimensions.Parser.UnitTable do
   @moduledoc false
 
   def from_abbr("nm"), do: ExDimensions.Spatial.Nanometers
-  def from_abbr("μm"), do: ExDimensions.Spatial.Micrometers
+  def from_abbr("um"), do: ExDimensions.Spatial.Micrometers
   def from_abbr("mm"), do: ExDimensions.Spatial.Millimeters
   def from_abbr("m"), do: ExDimensions.Spatial.Meters
   def from_abbr("km"), do: ExDimensions.Spatial.Kilometers
@@ -22,13 +22,13 @@ defmodule ExDimensions.Parser do
   # ft^2 <- a compound unit
   # ft^1/s^1 <- a rational unit
   # ft^2/s^2 <- a rational unit made of compound units
-  # 
-  # the ^1 is required despite it being redundant because the 
+  #
+  # the ^1 is required despite it being redundant because the
   # exponent notation is treated as a delimiter
   #
   # the combinators collectively declare that 0..n units
   # followed by an optional "/" for rational units, followed
-  # by 0..n units in the denominator is valid 
+  # by 0..n units in the denominator is valid
   unit_str =
     ascii_string([?a..?z], min: 1)
     |> optional(string("^"))

--- a/lib/ex_dimensions/types/spatial.ex
+++ b/lib/ex_dimensions/types/spatial.ex
@@ -45,7 +45,7 @@ defmodule ExDimensions.Spatial.Micrometers do
 
   @behaviour ExDimensions.Unit
 
-  def abbr, do: "μm"
+  def abbr, do: "um"
 end
 
 defmodule ExDimensions.Spatial.Millimeters do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Units.MixProject do
   def project do
     [
       app: :ex_dimensions,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/ecto_unit_field_test.exs
+++ b/test/ecto_unit_field_test.exs
@@ -27,4 +27,37 @@ defmodule ExDimensions.EctoUnitFieldTest do
              value: 43
            }
   end
+
+  test "deserialization of all units" do
+    units = [
+      ExDimensions.Spatial.Nanometers,
+      ExDimensions.Spatial.Micrometers,
+      ExDimensions.Spatial.Millimeters,
+      ExDimensions.Spatial.Meters,
+      ExDimensions.Spatial.Kilometers,
+      ExDimensions.Spatial.Inches,
+      ExDimensions.Spatial.Feet,
+      ExDimensions.Spatial.Yards,
+      ExDimensions.Spatial.Miles
+    ]
+
+    units |> Enum.each(fn(unit) -> assert_deserialization(unit) end)
+  end
+
+  defp assert_deserialization(unit) do
+    {:ok, quantity} =
+      ExDimensions.Ecto.UnitField.load(%{
+        "value" => 28,
+        "units" => "#{unit.abbr()}^1"
+      })
+
+    assert quantity == %ExDimensions.Quantity{
+      denom: [],
+      units: [
+        [unit],
+      ],
+      value: 28
+    }
+  end
+
 end


### PR DESCRIPTION
* Change serialization for Micrometers from `μm` to `um` (breaking change)
* Change deserialization Micrometers from `μm` to `um` (breaking change)
* Add unit tests for deserialization
* Bump the minor version